### PR TITLE
go.mod requires path as github.com/concogbyte/shosubgo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,21 @@ Small tool to Grab subdomains using Shodan api.
 
 ## Install
 
+Until master is updated, this will not work.
+
 ```bash
 $ go get github.com/incogbyte/shosubgo/apishodan
 $ go build main.go
 ```
+
+To build from source, now that Go does not support relative addressing:
+In main.go, change ./apishodan to apishodan in imports
+Move apishodan/api.go to the /usr/lib/go-<version>/src/ folder
+
+```bash
+$ go build main.go
+```
+Standard usage follows
 
 ## Usage
 ```bash

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ $ go build main.go
 ```
 
 To build from source, now that Go does not support relative addressing:
-In main.go, change ./apishodan to apishodan in imports
-Move apishodan/api.go to the /usr/lib/go-<version>/src/ folder
+- In main.go, change ./apishodan to apishodan in imports
+- Move apishodan/api.go to the /usr/lib/go-<version>/src/ folder
 
 ```bash
 $ go build main.go

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/zer0koan/shosubgo
+module github.com/incogbyte/shosubgo
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module shosubgo
+module github.com/zer0koan/shosubgo
 
 go 1.16
 

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"github.com/incogbyte/shosubgo/apishodan"
+	"apishodan"
 )
 
 const Author = "inc0gbyt3"

--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"os"
 
-	"apishodan"
+	"./apishodan"
 )
 
 const Author = "inc0gbyt3"


### PR DESCRIPTION
Installation stalls when parsing go.mod. It has an issue with module declaration of shosubgo, saying that github.com/incogbyte/shosubgo is required