### PR TITLE
support for reading domains from a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ go install github.com/incogbyte/shosubgo@latest
 
 ## Usage
 ```bash
-go run main.go -d target.com -s YourAPIKEY
+go run main.go -d target.com -s YourAPIKEY / go run main.go -f file -s YourAPIKEY
 ```
 ## Usage download from releases:
 
@@ -25,6 +25,7 @@ https://github.com/incogbyte/shosubgo/releases/tag/1.1
 # From Download Releases
 
 ./shosubgo_linux -d target.com -s YourAPIKEY
+./shosubgo_linux -f file -s YourAPIKEY
 ```
 
 ![shosubgo](https://raw.githubusercontent.com/incogbyte/shosubgo/master/shosubgo.png)

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"flag"
 	"fmt"
 	"log"
@@ -16,57 +17,86 @@ func main() {
 	shodanKey := flag.String("s", "", "> Shodan api key")
 	verbose := flag.Bool("v", false, "> Show all output")
 	fileName := flag.String("o", "", "> Save domains into a file")
+	inputFile := flag.String("f", "", "> File containing domains to find subdomains")
 	flag.Parse()
 
-	if *domain == "" || *shodanKey == "" {
-		fmt.Printf("[*] Usage %s -d target.com -s MYShodaNKey\n", os.Args[0])
-		fmt.Printf("[*] Author: %s \n\n thanks for using this tool =) PR are welcome \n", Author)
+	if *domain == "" && *inputFile == "" {
+		fmt.Printf("[*] Usage: %s -d target.com -s MYShodaNKey [-f input_file]\n", os.Args[0])
+		fmt.Printf("[*] Author: %s\n", Author)
 		os.Exit(1)
 	}
 
 	apiKey := apishodan.New(*shodanKey)
 
-	domainSearch := *domain
+	var domains []string
 
-	subdomain, err := apiKey.GetSubdomain(domainSearch)
-	if err != nil {
-		log.Panicln(err)
+	if *domain != "" {
+		// Use domain from command-line argument (-d)
+		domains = append(domains, *domain)
 	}
 
-	if *verbose == true {
+	if *inputFile != "" {
+		// Read domains from file specified by -f flag
+		fileDomains, err := readDomainsFromFile(*inputFile)
+		if err != nil {
+			log.Fatalf("Failed to read domains from file: %v", err)
+		}
+		domains = append(domains, fileDomains...)
+	}
 
-		info, err := apiKey.InfoAccount()
-
+	for _, domainSearch := range domains {
+		subdomain, err := apiKey.GetSubdomain(domainSearch)
 		if err != nil {
 			log.Panicln(err)
 		}
 
-		fmt.Printf(
-			"[*] Credits: %d\nScan Credits: %d \n\n",
-			info.QueryCredits, info.ScanCredits)
-
-		for _, v := range subdomain.Data {
-			d := v.SubD + subdomain.Domain
-			fmt.Printf("[*] Domain: %s\nIP/DNS :%s\nLast Scan made by shodan:%s\n", d, v.Value, v.LastSeen)
-		}
-
-	} else {
-		for _, v := range subdomain.SubDomains {
-			if *fileName != "" {
-				f, err := os.Create(*fileName)
-				if err != nil {
-					log.Fatal(err)
-				}
-
-				defer f.Close()
-
-				_, err2 := f.WriteString(v + "\n")
-				if err2 != nil {
-					log.Fatal(err2)
-				}
-				fmt.Println("[*] DONE write files")
+		if *verbose == true {
+			info, err := apiKey.InfoAccount()
+			if err != nil {
+				log.Panicln(err)
 			}
-			fmt.Printf("%s.%s\n", v, domainSearch)
+			fmt.Printf("[*] Credits: %d\nScan Credits: %d\n\n", info.QueryCredits, info.ScanCredits)
+
+			for _, v := range subdomain.Data {
+				d := v.SubD + subdomain.Domain
+				fmt.Printf("[*] Domain: %s\nIP/DNS: %s\nLast Scan made by Shodan: %s\n", d, v.Value, v.LastSeen)
+			}
+		} else {
+			for _, v := range subdomain.SubDomains {
+				if *fileName != "" {
+					f, err := os.OpenFile(*fileName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+					if err != nil {
+						log.Fatal(err)
+					}
+					defer f.Close()
+
+					_, err = f.WriteString(v + "\n")
+					if err != nil {
+						log.Fatal(err)
+					}
+					fmt.Println("[*] DONE writing to file:", *fileName)
+				}
+				fmt.Printf("%s.%s\n", v, domainSearch)
+			}
 		}
 	}
+}
+
+func readDomainsFromFile(filename string) ([]string, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	var domains []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		domains = append(domains, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return domains, nil
 }


### PR DESCRIPTION
This pull request enhances the functionality of the tool by adding support for reading domains from a file specified via the `-f` flag. This feature provides flexibility to input multiple domains from a text file, making it easier to perform subdomain enumeration.